### PR TITLE
Fix example registration of Twig Service Provider

### DIFF
--- a/docs/features/templates.html
+++ b/docs/features/templates.html
@@ -79,8 +79,11 @@ _before_ you invoke your application's `run()` method.
 // Create Slim app
 $app = new \Slim\App();
 
+// Get DI Container
+$container = $app->getContainer();
+
 // Register Twig View service
-$app->register(new \Slim\Views\Twig('path/to/templates', [
+$container->register(new \Slim\Views\Twig('path/to/templates', [
     'cache' => 'path/to/cache'
 ]));
 
@@ -105,6 +108,9 @@ service.
 ```php
 // Create Slim app
 $app = new \Slim\App();
+
+// Get DI Container
+$container = $app->getContainer();
 
 // Register Twig View helper
 $app->register(new \Slim\Views\Twig('path/to/templates', [


### PR DESCRIPTION
Since commit https://github.com/slimphp/Slim/commit/ea4f1fcaf77c264abc2756a5a1e5640f4c24239b `\Slim\App` is not a instance of `\Pimple\Container` anymore so the container has to be fetched from the application before a Service Provider can be registered.

See also https://github.com/slimphp/Slim/issues/1250
